### PR TITLE
tests: add script helpers, test chainid return value

### DIFF
--- a/packages/integration-tests/test/rpc.spec.ts
+++ b/packages/integration-tests/test/rpc.spec.ts
@@ -23,7 +23,7 @@ const mnemonic =
 // Address derived at m/44'/60'/0'/0 of test mnemonic
 const etherbase = '0x9858EfFD232B4033E47d90003D41EC34EcaEda94'
 
-describe('sendTransaction', () => {
+describe('Transactions', () => {
   let provider
 
   before(async () => {
@@ -132,5 +132,11 @@ describe('sendTransaction', () => {
     for (const estimate of estimates) {
       estimate.toNumber().should.eq(7999999)
     }
+  })
+
+  it('should get correct chainid', async () => {
+    const chainId = await provider.send('eth_chainId', [])
+    chainId.should.eq('0x1a4')
+    parseInt(chainId, 16).should.eq(420)
   })
 })

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -18,7 +18,7 @@ GIT_COMMIT_LABEL_KEY="io.optimism.repo.git.hash"
 
 REMOTE=origin
 TEMP=/tmp/optimistic-rollup-integration-tests
-mkdir -p $TEMP
+mkdir -p "$TEMP"
 
 cd "$TEMP"
 if [ ! -d "optimism-monorepo"  ]; then
@@ -28,74 +28,72 @@ if [ ! -d "go-ethereum" ]; then
     git clone https://github.com/ethereum-optimism/go-ethereum
 fi
 
-(
-    # build the microservices
-    cd optimism-monorepo
-    git pull $REMOTE
+# build the microservices
+cd "$TEMP/optimism-monorepo"
+git pull "$REMOTE"
 
-    MICROSERVICES_GIT_HASH=$(git rev-parse "$MICROSERVICES_GIT_REF")
-    # if the latest microservices aren't build, then build them
-    HAS_MICROSERVICES=$(docker images eth-optimism/rollup-microservices \
-        --filter "label=$PROJECT_LABEL" \
-        --filter "label=$COMPOSE_SERVICE_LABEL_KEY=microservices" \
-        --filter "label=$GIT_COMMIT_LABEL_KEY=$MICROSERVICES_GIT_HASH" \
-        --format='{{.ID}}')
+MICROSERVICES_GIT_HASH=$(git rev-parse "$MICROSERVICES_GIT_REF")
+# if the latest microservices aren't build, then build them
+HAS_MICROSERVICES=$(docker images eth-optimism/rollup-microservices \
+    --filter "label=$PROJECT_LABEL" \
+    --filter "label=$COMPOSE_SERVICE_LABEL_KEY=microservices" \
+    --filter "label=$GIT_COMMIT_LABEL_KEY=$MICROSERVICES_GIT_HASH" \
+    --format='{{.ID}}')
 
-    # the dockerfile for the microservices is in optimism-monorepo
-    # and the dockerfile for the db is in optimism-monorepo/db.
-    if [[ -z "$HAS_MICROSERVICES" ]]; then
-        git checkout "$MICROSERVICES_GIT_REF"
-        yarn install
-        echo "Building eth-optimism/rollup-microservices:$MICROSERVICES_TAG"
-        docker build \
-            --label "$PROJECT_LABEL" \
-            --label "$COMPOSE_SERVICE_LABEL_KEY=microservices" \
-            --label "$GIT_BRANCH_LABEL_KEY=$MICROSERVICES_GIT_REF" \
-            --label "$GIT_COMMIT_LABEL_KEY=$MICROSERVICES_GIT_HASH" \
-            -t eth-optimism/rollup-microservices:$MICROSERVICES_TAG .
-    fi
+# the dockerfile for the microservices is in optimism-monorepo
+# and the dockerfile for the db is in optimism-monorepo/db.
+if [[ -z "$HAS_MICROSERVICES" ]]; then
+    git checkout "$MICROSERVICES_GIT_REF"
+    git pull
+    yarn install
+    echo "Building eth-optimism/rollup-microservices:$MICROSERVICES_TAG"
+    docker build \
+        --label "$PROJECT_LABEL" \
+        --label "$COMPOSE_SERVICE_LABEL_KEY=microservices" \
+        --label "$GIT_BRANCH_LABEL_KEY=$MICROSERVICES_GIT_REF" \
+        --label "$GIT_COMMIT_LABEL_KEY=$MICROSERVICES_GIT_HASH" \
+        -t eth-optimism/rollup-microservices:$MICROSERVICES_TAG .
+fi
 
-    cd ..
+# build postgres
+cd "$TEMP/optimism-monorepo/db"
+POSTGRES_GIT_HASH=$(git rev-parse "$POSTGRES_GIT_REF")
+HAS_POSTGRES=$(docker images eth-optimism/postgres \
+    --filter "label=$PROJECT_LABEL" \
+    --filter "label=$COMPOSE_SERVICE_LABEL_KEY=postgres" \
+    --filter "label=$GIT_COMMIT_LABEL_KEY=$POSTGRES_GIT_HASH" \
+    --format='{{.ID}}')
 
-    cd optimism-monorepo/db
-    POSTGRES_GIT_HASH=$(git rev-parse "$POSTGRES_GIT_REF")
-    HAS_POSTGRES=$(docker images eth-optimism/postgres \
-        --filter "label=$PROJECT_LABEL" \
-        --filter "label=$COMPOSE_SERVICE_LABEL_KEY=postgres" \
-        --filter "label=$GIT_COMMIT_LABEL_KEY=$POSTGRES_GIT_HASH" \
-        --format='{{.ID}}')
+if [[ -z "$HAS_POSTGRES" ]]; then
+    git checkout "$POSTGRES_GIT_REF"
+    git pull
+    echo "Building eth-optimism/postgres:$POSTGRES_TAG"
+    docker build \
+        --label "$PROJECT_LABEL" \
+        --label "$COMPOSE_SERVICE_LABEL_KEY=postgres" \
+        --label "$GIT_BRANCH_LABEL_KEY=$POSTGRES_GIT_REF" \
+        --label "$GIT_COMMIT_LABEL_KEY=$POSTGRES_GIT_HASH" \
+        -t eth-optimism/postgres:$POSTGRES_TAG .
+fi
 
-    if [[ -z "$HAS_POSTGRES" ]]; then
-        git checkout "$POSTGRES_GIT_REF"
-        echo "Building eth-optimism/postgres:$POSTGRES_TAG"
-        docker build \
-            --label "$PROJECT_LABEL" \
-            --label "$COMPOSE_SERVICE_LABEL_KEY=postgres" \
-            --label "$GIT_BRANCH_LABEL_KEY=$POSTGRES_GIT_REF" \
-            --label "$GIT_COMMIT_LABEL_KEY=$POSTGRES_GIT_HASH" \
-            -t eth-optimism/postgres:$POSTGRES_TAG .
-        cd ..
-    fi
-)
+# build l2 geth
+cd "$TEMP/go-ethereum"
+git pull "$REMOTE"
+GETH_L2_GIT_HASH=$(git rev-parse "$GETH_L2_GIT_REF")
+HAS_L2_GETH=$(docker images eth-optimism/geth \
+    --filter "label=$PROJECT_LABEL" \
+    --filter "label=$COMPOSE_SERVICE_LABEL_KEY=geth_l2" \
+    --filter "label=$GIT_COMMIT_LABEL_KEY=$GETH_L2_GIT_HASH" \
+    --format='{{.ID}}')
 
-(
-    cd go-ethereum
-    git pull "$REMOTE"
-    GETH_L2_GIT_HASH=$(git rev-parse "$GETH_L2_GIT_REF")
-    HAS_L2_GETH=$(docker images eth-optimism/geth \
-        --filter "label=$PROJECT_LABEL" \
-        --filter "label=$COMPOSE_SERVICE_LABEL_KEY=geth_l2" \
-        --filter "label=$GIT_COMMIT_LABEL_KEY=$GETH_L2_GIT_HASH" \
-        --format='{{.ID}}')
-
-    if [[ -z "$HAS_L2_GETH" ]]; then
-        git checkout "$GETH_L2_GIT_REF"
-        echo "Building eth-optimism/geth:$GETH_L2_TAG"
-        docker build \
-            --label "$PROJECT_LABEL" \
-            --label "$COMPOSE_SERVICE_LABEL_KEY=geth_l2" \
-            --label "$GIT_BRANCH_LABEL_KEY=$GETH_L2_GIT_REF" \
-            --label "$GIT_COMMIT_LABEL_KEY=$GETH_L2_GIT_HASH" \
-            -t eth-optimism/geth:$GETH_L2_TAG .
-    fi
-)
+if [[ -z "$HAS_L2_GETH" ]]; then
+    git checkout "$GETH_L2_GIT_REF"
+    git pull
+    echo "Building eth-optimism/geth:$GETH_L2_TAG"
+    docker build \
+        --label "$PROJECT_LABEL" \
+        --label "$COMPOSE_SERVICE_LABEL_KEY=geth_l2" \
+        --label "$GIT_BRANCH_LABEL_KEY=$GETH_L2_GIT_REF" \
+        --label "$GIT_COMMIT_LABEL_KEY=$GETH_L2_GIT_HASH" \
+        -t eth-optimism/geth:$GETH_L2_TAG .
+fi

--- a/scripts/remove-containers.sh
+++ b/scripts/remove-containers.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Remove stopped containers
+docker container ls -a --format='{{.ID}}' \
+    xargs docker rm

--- a/scripts/remove-integration-test-image.sh
+++ b/scripts/remove-integration-test-image.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+docker container ls -a \
+    --filter='name=optimistic-rollup-integration-tests_integration_tests' \
+    --format='{{.ID}}' \
+    | xargs docker rm 2>/dev/null
+
+docker images \
+    optimistic-rollup-integration-tests_integration_tests \
+    --format='{{.ID}}' \
+    | xargs docker rmi 2>/dev/null
+


### PR DESCRIPTION
## Description

- Adds some helper scripts for cleaning out local images
- Adds test coverage of new chain id (420) from the RPC endpoint `eth_chainId`
- Minor cleanup in the test script

To repro locally:

```bash
$ ./scripts/test.sh -g update-chainid -m update-chainid
```

Note this is not ready to merge until all tests in the monorepo are passing.

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [ ] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
