### PR TITLE
faster builds: mounting the tests

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 FROM node:11
 
 # Used to mount the code so image isn't re-built every time code changes
-WORKDIR /mnt/integration-tests/packages/integration-tests
+WORKDIR /mnt/packages/integration-tests
 
 # This is required for the wait_for_postgres script
 RUN apt-get update

--- a/README.md
+++ b/README.md
@@ -18,17 +18,23 @@ refs. `scripts/test.sh` will autotmatically build images that don't already
 exist and run them as part of the integration test suite.
 
 ```bash
-$ ./scripts/test.sh -h
-
+$ ./scripts/test.sh
 Build docker images and test using git branches.
 
 CLI Arguments:
   -m|--microservices   - microservices branch
   -p|--postgres        - postgres branch
   -g|--gethl2          - gethl2 branch
+  -l|--logs            - grep -E log filter
 
-Default values are master.
+Default values for branches are master.
 Will rebuild if new commits to a branch are detected.
+
+
+For filtering logs with -l, use the | to delimit names of services.
+Possible services are geth_l2, postgres, l1_chain, integration_tests.
+Example:
+$ ./scripts/test.sh -l 'geth_l2|integration_tests'
 
 Example:
 $ ./scripts/test.sh -p master -m new-feature-x -g new-feature-y

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,13 +1,16 @@
 ######### LOCAL DEV #########
-REBUILD=1                            # Set to anything to rebuild when running locally in Docker
-FETCH_DEPS=                         # Set to anything to fetch deps when rebuilding locally in Docker
-
+# Set to anything to rebuild when running locally in Docker
+REBUILD=1
+# Set to anything to fetch deps when rebuilding locally in Docker
+FETCH_DEPS
 
 ######### SHARED #########
-POSTGRES_PORT=5432                                                              # (Required) Should almost always be 5432
-POSTGRES_USER=test                                                              # (Required) The user to use to connect to the db
-POSTGRES_PASSWORD=test                                                          # (Required) The password to use to connect to the db
-
+# (Required) Should almost always be 5432
+POSTGRES_PORT=5432
+# (Required) The user to use to connect to the db
+POSTGRES_USER=test
+# (Required) The password to use to connect to the db
+POSTGRES_PASSWORD=test
 
 ######### L2 GETH VARS #########
 TARGET_GAS_LIMIT
@@ -25,79 +28,123 @@ L1_SEQUENCER_ADDRESS=0xaaa6c3FBA9be28B4e4777Cdcb9Ed781199083358
 L1_CONTRACT_OWNER_ADDRESS=0xbbb3F0b64561dC149bf9c10e95f2D10AE552F25b
 FORCE_INCLUSION_PERIOD_SECONDS=1500
 
-LOG_NEW_LINES=1                                                                 # Logs new lines instead of <\n>
+# Logs new lines instead of <\n>
+LOG_NEW_LINES=1
 
 # Container
-STARTUP_WAIT_TIMEOUT=30                                                         # The amount of times to attempt to connect to L2 geth before failing (set to -1 if not to wait for L2 geth).
+# The amount of times to attempt to connect to L2 geth before failing (set to -1 if not to wait for L2 geth).
+STARTUP_WAIT_TIMEOUT=30
 
 # Logging
-DEBUG=info*,error*,warn*,debug*                                                 # The comma-separated logging patterns to match (common options are `error*`, `info*`, `warn*`, and `debug*`)
+# The comma-separated logging patterns to match (common options are `error*`, `info*`, `warn*`, and `debug*`)
+DEBUG=info*,error*,warn*,debug*
 
 # Postgres
-POSTGRES_HOST=postgres                                                          # (Required) The host DNS entry / IP for the postgres DB
-POSTGRES_DATABASE=rollup                                                        # (Required) The database name to connect to (should be `rollup`)
-POSTGRES_CONNECTION_POOL_SIZE                                                   # The connection pool size for postgres (defaults to 20)
-POSTGRES_USE_SSL                                                                # Set to anything to indicate that SSL should be used in the connection
+# (Required) The host DNS entry / IP for the postgres DB
+POSTGRES_HOST=postgres
+# (Required) The database name to connect to (should be `rollup`)
+POSTGRES_DATABASE=rollup
+# The connection pool size for postgres (defaults to 20)
+POSTGRES_CONNECTION_POOL_SIZE
+# Set to anything to indicate that SSL should be used in the connection
+POSTGRES_USE_SSL
 
 # L1 Node
-L1_NODE_WEB3_URL=http://l1_chain:9545                                           # The URL of the L1 node
-FINALITY_DELAY_IN_BLOCKS=1                                                      # The number of block confirmations required to consider a transaction final on L1
+# The URL of the L1 node
+L1_NODE_WEB3_URL=http://l1_chain:9545
+# The number of block confirmations required to consider a transaction final on L1
+FINALITY_DELAY_IN_BLOCKS=1
 
 # L2 Node
-L2_NODE_WEB3_URL=http://geth_l2:8545                                            # The URL of the L2 node
+# The URL of the L2 node
+L2_NODE_WEB3_URL=http://geth_l2:8545
 
 # L1 Submitters
-L1_SEQUENCER_PRIVATE_KEY=df8b81d840b9cafc8cd68cf94f093726b174b5f109eba11a3f2a559e5f9e8bce   # Address= 0xaaa6c3FBA9be28B4e4777Cdcb9Ed781199083358           # The private key to use to submit Sequencer Transaction Batches
-L1_STATE_ROOT_SUBMITTER_PRIVATE_KEY=06caa6f48604a58872e27db8c2980584e20faab37613f51383bb5be62db80c50  # Address= 0xbbb3F0b64561dC149bf9c10e95f2D10AE552F25b           # The private key to use to submit State Root Batches
+# Address= 0xaaa6c3FBA9be28B4e4777Cdcb9Ed781199083358
+# The private key to use to submit Sequencer Transaction Batches
+L1_SEQUENCER_PRIVATE_KEY=df8b81d840b9cafc8cd68cf94f093726b174b5f109eba11a3f2a559e5f9e8bce
+# Address= 0xbbb3F0b64561dC149bf9c10e95f2D10AE552F25b
+# The private key to use to submit State Root Batches
+L1_STATE_ROOT_SUBMITTER_PRIVATE_KEY=06caa6f48604a58872e27db8c2980584e20faab37613f51383bb5be62db80c50
 
 # Shared Contracts
-CANONICAL_TRANSACTION_CHAIN_CONTRACT_ADDRESS=0xed31Ba5446D983cC6B128EEcd349D10bc0F80a66     # (Required) The address of the CanonicalTransactionChain contract
-STATE_COMMITMENT_CHAIN_CONTRACT_ADDRESS=0x3A098b2982EC25772f16C57f2C1D0463E052ec59          # (Required) The address of the StateCommitmentChain contract
+# (Required) The address of the CanonicalTransactionChain contract
+CANONICAL_TRANSACTION_CHAIN_CONTRACT_ADDRESS=0xed31Ba5446D983cC6B128EEcd349D10bc0F80a66
+# (Required) The address of the StateCommitmentChain contract
+STATE_COMMITMENT_CHAIN_CONTRACT_ADDRESS=0x3A098b2982EC25772f16C57f2C1D0463E052ec59
 
 # L1 Chain Data Persister (needs Postgres & L1 Node vars above)
-L1_TO_L2_TRANSACTION_QUEUE_CONTRACT_ADDRESS=0xA1B22bF35196AFCE0927D94ce8ad4C4b7bb6F005      # (Required) The address of the L1ToL2TransactionQueue contract
-SAFETY_TRANSACTION_QUEUE_CONTRACT_ADDRESS=0x3a3BEFB4942cF20A69C8eb4FDB8957223Da57fa2        # (Required) The address of the SafetyTransactionQueue contract
-L1_CHAIN_DATA_PERSISTER_DB_PATH=/mnt/l1-node                                                # (Required) The filepath where to locate (or create) the L1 Chain Data Persister LevelDB database
-L1_EARLIEST_BLOCK=0                                                                   # (Required) The earliest block to sync on L1 to start persisting data
+# (Required) The address of the L1ToL2TransactionQueue contract
+L1_TO_L2_TRANSACTION_QUEUE_CONTRACT_ADDRESS=0xA1B22bF35196AFCE0927D94ce8ad4C4b7bb6F005
+# (Required) The address of the SafetyTransactionQueue contract
+SAFETY_TRANSACTION_QUEUE_CONTRACT_ADDRESS=0x3a3BEFB4942cF20A69C8eb4FDB8957223Da57fa2
+# (Required) The filepath where to locate (or create) the L1 Chain Data Persister LevelDB database
+L1_CHAIN_DATA_PERSISTER_DB_PATH=/mnt/l1-node
+# (Required) The earliest block to sync on L1 to start persisting data
+L1_EARLIEST_BLOCK=0
 
 # L2 Chain Data Persister (needs Postgres & L2 Node vars above)
-L2_CHAIN_DATA_PERSISTER_DB_PATH=/mnt/l2-node                                                # (Required) The filepath where to locate (or create) the L2 Chain Data Persister LevelDB database
+# (Required) The filepath where to locate (or create) the L2 Chain Data Persister LevelDB database
+L2_CHAIN_DATA_PERSISTER_DB_PATH=/mnt/l2-node
 
 # Geth Submission Queuer (needs Postgres vars above)
-IS_SEQUENCER_STACK=1                                                                        # (Required) Set if this is queueing Geth submissions for a sequencer (and not _just_ a verifier)
-GETH_SUBMISSION_QUEUER_PERIOD_MILLIS=1000                                                        # The period in millis at which the GethSubmissionQueuer should attempt to queue an L2 Geth submission (defaults to 10,000)
+# (Required) Set if this is queueing Geth submissions for a sequencer (and not _just_ a verifier)
+IS_SEQUENCER_STACK=1
+# The period in millis at which the GethSubmissionQueuer should attempt to queue an L2 Geth submission (defaults to 10,000)
+GETH_SUBMISSION_QUEUER_PERIOD_MILLIS=1000
 
 # Queued Geth Submitter (needs Postgres & L2 Node vars above)
-SUBMIT_TO_L2_PRIVATE_KEY=65b2a66430ebe04afd0471cfb309f1cd327f61bdfef6ba3cb082f3f85bc1264f   # (Required) The PK to use to sign batches to send to geth (deprecated)
-QUEUED_GETH_SUBMITTER_PERIOD_MILLIS=1000                                                         # The period in millis at which the QueuedGethSubmitter should attempt to send L2 Geth submissions (defaults to 10,000)
+# (Required) The PK to use to sign batches to send to geth (deprecated)
+SUBMIT_TO_L2_PRIVATE_KEY=65b2a66430ebe04afd0471cfb309f1cd327f61bdfef6ba3cb082f3f85bc1264f
+# The period in millis at which the QueuedGethSubmitter should attempt to send L2 Geth submissions (defaults to 10,000)
+QUEUED_GETH_SUBMITTER_PERIOD_MILLIS=1000
 
 # Canonical Transaction Chain Batch Creator (needs Postgres vars above)
-CANONICAL_CHAIN_MIN_BATCH_SIZE=1                                                            # The minimum batch size to build -if fewer than this number of transactions are ready, a batch will not be created (defaults to 10)
-CANONICAL_CHAIN_MAX_BATCH_SIZE=2                                                           # The maximum batch size to build -if more than this number of transactions are ready, they will be split into multiple batches of at most this size (defaults to 100)
-CANONICAL_CHAIN_BATCH_CREATOR_PERIOD_MILLIS=1000                                           # The period in millis at which the CanonicalChainBatchCreator should attempt to create Canonical Chain Batches (defaults to 10,000)
+# The minimum batch size to build -if fewer than this number of transactions are ready, a batch will not be created (defaults to 10)
+CANONICAL_CHAIN_MIN_BATCH_SIZE=1
+# The maximum batch size to build -if more than this number of transactions are ready, they will be split into multiple batches of at most this size (defaults to 100)
+CANONICAL_CHAIN_MAX_BATCH_SIZE=2
+# The period in millis at which the CanonicalChainBatchCreator should attempt to create Canonical Chain Batches (defaults to 10,000)
+CANONICAL_CHAIN_BATCH_CREATOR_PERIOD_MILLIS=1000
 
 # Canonical Transaction Chain Batch Submitter (needs Postgres, L1 Node, L1 Submitters, and CANONICAL_TRANSACTION_CHAIN_CONTRACT_ADDRESS vars above)
-CANONICAL_CHAIN_BATCH_SUBMITTER_PERIOD_MILLIS=1000                                               # The period in millis at which the CanonicalChainBatchCreator should attempt to create Canonical Chain Batches (defaults to 10,000)
+# The period in millis at which the CanonicalChainBatchCreator should attempt to create Canonical Chain Batches (defaults to 10,000)
+CANONICAL_CHAIN_BATCH_SUBMITTER_PERIOD_MILLIS=1000
 
 # State Commitment Chain Batch Creator (needs Postgres vars above)
-STATE_COMMITMENT_CHAIN_MIN_BATCH_SIZE=1                                                     # The minimum batch size to build -if fewer than this number of transactions are ready, a batch will not be created (defaults to 10)
-STATE_COMMITMENT_CHAIN_MAX_BATCH_SIZE=4                                                   # The maximum batch size to build -if more than this number of transactions are ready, they will be split into multiple batches of at most this size (defaults to 100)
-STATE_COMMITMENT_CHAIN_BATCH_CREATOR_PERIOD_MILLIS=1000                                    # The period in millis at which the StateCommitmentChainBatchCreator should attempt to create StateCommitmentChain Batches (defaults to 10,000)
+# The minimum batch size to build -if fewer than this number of transactions are ready, a batch will not be created (defaults to 10)
+STATE_COMMITMENT_CHAIN_MIN_BATCH_SIZE=1
+# The maximum batch size to build -if more than this number of transactions are ready, they will be split into multiple batches of at most this size (defaults to 100)
+STATE_COMMITMENT_CHAIN_MAX_BATCH_SIZE=4
+# The period in millis at which the StateCommitmentChainBatchCreator should attempt to create StateCommitmentChain Batches (defaults to 10,000)
+STATE_COMMITMENT_CHAIN_BATCH_CREATOR_PERIOD_MILLIS=1000
 
 # State Commitment Chain Batch Submitter (needs Postgres, L1 Node, L1 Submitters, STATE_COMMITMENT_CHAIN_CONTRACT_ADDRESS vars above)
-STATE_COMMITMENT_CHAIN_BATCH_SUBMITTER_PERIOD_MILLIS=1000                                        # The period in millis at which the StateCommitmentChainBatchCreator should attempt to create StateCommitmentChain Batches (defaults to 10,000)
+# The period in millis at which the StateCommitmentChainBatchCreator should attempt to create StateCommitmentChain Batches (defaults to 10,000)
+STATE_COMMITMENT_CHAIN_BATCH_SUBMITTER_PERIOD_MILLIS=1000
 
 # Fraud Detector
-FRAUD_DETECTOR_PERIOD_MILLIS=1000                                                                # The period in millis at which the FraudDetector should run (defaults to 10,000)
-REALERT_ON_UNRESOLVED_FRAUD_EVERY_N_FRAUD_DETECTOR_RUNS                                     # The number of runs after which a detected fraud, if still present, should re-alert (via error logs) (defaults to 10)
+# The period in millis at which the FraudDetector should run (defaults to 10,000)
+FRAUD_DETECTOR_PERIOD_MILLIS=1000
+# The number of runs after which a detected fraud, if still present, should re-alert (via error logs) (defaults to 10)
+REALERT_ON_UNRESOLVED_FRAUD_EVERY_N_FRAUD_DETECTOR_RUNS
 
 # Which Services to run (respective vars must be configured above)
-RUN_L1_CHAIN_DATA_PERSISTER=1                                                               # Set to anything to run L1 Chain Data Persister
-RUN_L2_CHAIN_DATA_PERSISTER=1                                                               # Set to anything to run L2 Chain Data Persister
-RUN_GETH_SUBMISSION_QUEUER=1                                                                # Set to anything to run Geth Submission Queuer
-RUN_QUEUED_GETH_SUBMITTER=1                                                                 # Set to anything to run Queued Geth Submitter
-RUN_CANONICAL_CHAIN_BATCH_CREATOR=1                                                         # Set to anything to run Canonical Chain Batch Creator
-RUN_CANONICAL_CHAIN_BATCH_SUBMITTER=1                                                       # Set to anything to run Canonical Chain Batch Submitter
-RUN_STATE_COMMITMENT_CHAIN_BATCH_CREATOR=1                                                  # Set to anything to run State Commitment Chain Batch Creator
-RUN_STATE_COMMITMENT_CHAIN_BATCH_SUBMITTER=1                                                # Set to anything to run State Commitment Chain Batch Submitter
-RUN_FRAUD_DETECTOR=1                                                                        # Set to anything to run Fraud Detector
+# Set to anything to run L1 Chain Data Persister
+RUN_L1_CHAIN_DATA_PERSISTER=1
+# Set to anything to run L2 Chain Data Persister
+RUN_L2_CHAIN_DATA_PERSISTER=1
+# Set to anything to run Geth Submission Queuer
+RUN_GETH_SUBMISSION_QUEUER=1
+# Set to anything to run Queued Geth Submitter
+RUN_QUEUED_GETH_SUBMITTER=1
+# Set to anything to run Canonical Chain Batch Creator
+RUN_CANONICAL_CHAIN_BATCH_CREATOR=1
+# Set to anything to run Canonical Chain Batch Submitter
+RUN_CANONICAL_CHAIN_BATCH_SUBMITTER=1
+# Set to anything to run State Commitment Chain Batch Creator
+RUN_STATE_COMMITMENT_CHAIN_BATCH_CREATOR=1
+# Set to anything to run State Commitment Chain Batch Submitter
+RUN_STATE_COMMITMENT_CHAIN_BATCH_SUBMITTER=1
+# Set to anything to run Fraud Detector
+RUN_FRAUD_DETECTOR=1

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -5,9 +5,11 @@ services:
   integration_tests:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev
     env_file:
       - docker-compose.env
+    volumes:
+      - .:/mnt
 
   microservices:
     image: "eth-optimism/rollup-microservices:${MICROSERVICES_TAG}"

--- a/packages/integration-tests/exec/build_and_run.sh
+++ b/packages/integration-tests/exec/build_and_run.sh
@@ -15,7 +15,7 @@ if [ -n "$REBUILD" ]; then
 
   if [ -n "$FETCH_DEPS" ]; then
     echo -e "\nFetching dependencies (this will take forever the first time time)..."
-    yarn --cwd $ROOT_DIR --verbose
+    yarn --cwd $ROOT_DIR --verbose --frozen-lockfile
   fi
 
   yarn --cwd $ROOT_DIR clean

--- a/packages/integration-tests/test/example.spec.ts
+++ b/packages/integration-tests/test/example.spec.ts
@@ -1,7 +1,0 @@
-import './setup'
-
-describe('Example Test', () => {
-  it('should all work juuuuuust right!', async () => {
-    console.log('This means it worked.')
-  })
-})

--- a/scripts/start-postgres.sh
+++ b/scripts/start-postgres.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script will start up a postgres container and mount the docker
+# volume used by the integration test suite in so that tools like `psql`
+# or pgadmin can observe the data in the database after integration tests
+# are ran.
+
+# The first argument is expected to be the tag, otherwise master is used
+
+TAG=${1:-"master"}
+IMAGE="eth-optimism/postgres"
+
+echo "Starting container $IMAGE:$TAG"
+
+docker run --rm \
+    -p 5432:5432 \
+    -v optimistic-rollup-integration-tests_postgres:/var/lib/postgresql/data \
+    "$IMAGE:$TAG"


### PR DESCRIPTION
## Description

The tests in this directory can now be mounted into the container to be ran instead of needing to build the container every time. It also moves the comments in the `docker-compose.env` file to different lines because of a bug where an unset variable was being set to `\s\s\s\s\s\s\s\s\s                 # this is the comment` where `\s` represents a whitespace.


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
