### PR TITLE
build: remove yarn verbose

### DIFF
--- a/exec/build_and_run.sh
+++ b/exec/build_and_run.sh
@@ -12,7 +12,7 @@ if [ -n "$REBUILD" ]; then
 
   if [ -n "$FETCH_DEPS" ]; then
     echo -e "\nFetching dependencies (this will take forever the first time time)..."
-    yarn --frozen-lockfile --verbose
+    yarn --frozen-lockfile
   fi
 
   yarn clean


### PR DESCRIPTION
## Description
Removes `--verbose` flag so that logs aren't huge

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
