### PR TITLE
tests: update now that l1BlockNumber is returning correctly

### DIFF
--- a/packages/integration-tests/test/rpc.spec.ts
+++ b/packages/integration-tests/test/rpc.spec.ts
@@ -169,9 +169,9 @@ describe('Transactions', () => {
       // There must be a single transaction
       assert(block.transactions.length === 1)
       const tx = block.transactions[0]
-      // The previous test sends a transaction directly to L2 so
-      // the l1BlockNumber is null
-      assert(tx.l1BlockNumber === null)
+      // The l1BlockNumber is 0 because there has not been a
+      // L1 to L2 transaction yet
+      assert(tx.l1BlockNumber === 0)
       // The `OptimismProvider` creates EthSign transactions
       assert(tx.txType === 'EthSign')
       // The transaction was sent directly to the sequencer so the

--- a/packages/integration-tests/test/rpc.spec.ts
+++ b/packages/integration-tests/test/rpc.spec.ts
@@ -169,9 +169,6 @@ describe('Transactions', () => {
       // There must be a single transaction
       assert(block.transactions.length === 1)
       const tx = block.transactions[0]
-      // The l1BlockNumber is 0 because there has not been a
-      // L1 to L2 transaction yet
-      assert(tx.l1BlockNumber === 0)
       // The `OptimismProvider` creates EthSign transactions
       assert(tx.txType === 'EthSign')
       // The transaction was sent directly to the sequencer so the


### PR DESCRIPTION
## Description

Fixes the tests so that https://github.com/ethereum-optimism/go-ethereum/pull/114 passes
The geth PR updates the return value of the `L1BlockNumber` so that it is no longer `null`. This deletes the test that asserts null so that PR coordination is easier.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
