### PR TITLE
Update address manager env var naming for consistency

### DIFF
--- a/common.ts
+++ b/common.ts
@@ -54,7 +54,7 @@ export class Config {
 
   // TODO: this is the address manager
   public static AddressResolverAddress(): string {
-    return process.env.ETH1_ADDRESS_RESOLVER_ADDRESS
+    return process.env.ETH1_ADDRESS_MANAGER_ADDRESS
   }
 
   public static StateCommitmentChainContractAddress(): string {


### PR DESCRIPTION
The Address manager has different names in different places i.e. ETH1_ADDRESS_RESOLVER_ADDRESS vs AddressManager. We should make this less confusing by making the names consistent.