### PR TITLE
config: remove dead config options

### DIFF
--- a/common.ts
+++ b/common.ts
@@ -48,17 +48,9 @@ export class Config {
   }
 
   /* Contracts */
-  public static CanonicalTransactionChainContractAddress(): string {
-    return process.env.CANONICAL_TRANSACTION_CHAIN_CONTRACT_ADDRESS
-  }
-
   // TODO: this is the address manager
   public static AddressResolverAddress(): string {
     return process.env.ETH1_ADDRESS_RESOLVER_ADDRESS
-  }
-
-  public static StateCommitmentChainContractAddress(): string {
-    return process.env.STATE_COMMITMENT_CHAIN_CONTRACT_ADDRESS
   }
 
   public static SequencerPrivateKey(): string {


### PR DESCRIPTION
## Description

This deletes some dead config options that are no longer used. We should be resolving all addresses from the address manager.

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
