### PR TITLE
Remove old gas estimate test

### DIFF
--- a/packages/x-domain/test/rpc.spec.ts
+++ b/packages/x-domain/test/rpc.spec.ts
@@ -155,4 +155,20 @@ describe('Basic RPC tests', () => {
       expect(price.toNumber()).to.equal(expected)
     })
   })
+
+  describe('eth_estimateGas', () => {
+    it('should return a gas estimate', async () => {
+      // Repeat this test for a series of possible transaction sizes.
+      for (const size of [0, 2, 8, 64, 256]) {
+        const estimate = await provider.estimateGas({
+          ...DEFAULT_TRANSACTION,
+          data: '0x' + '00'.repeat(size),
+        })
+
+        // Good enough for now. Make sure we actually get an estimate back.
+        // Really we just want to ensure that `estimateGas` didn't throw.
+        expect(estimate.toNumber()).to.be.a('number')
+      }
+    })
+  })
 })

--- a/packages/x-domain/test/rpc.spec.ts
+++ b/packages/x-domain/test/rpc.spec.ts
@@ -155,23 +155,4 @@ describe('Basic RPC tests', () => {
       expect(price.toNumber()).to.equal(expected)
     })
   })
-
-  // TODO: Fix this test when we update how we compute gas estimates.
-  describe('eth_estimateGas', () => {
-    it('should return block gas limit minus one', async () => {
-      // We currently fix gas price to TargetGasLimit-1
-      const expected = Config.TargetGasLimit() - 1
-
-      // Repeat this test for a series of possible transaction sizes to demonstrate that we always
-      // get the same estimate.
-      for (const size of [0, 2, 8, 64, 256]) {
-        const estimate = await provider.estimateGas({
-          ...DEFAULT_TRANSACTION,
-          data: '0x' + '00'.repeat(size),
-        })
-
-        expect(estimate.toNumber()).to.equal(expected)
-      }
-    })
-  })
 })


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Test will no longer be relevant once gas estimate fixes are merged. This is blocking getting those changes merged because this test fails.