### PR TITLE
Add support for Proxy__OVM_L1EthGateway

### DIFF
--- a/packages/x-domain/test/fee-payment.spec.ts
+++ b/packages/x-domain/test/fee-payment.spec.ts
@@ -61,16 +61,16 @@ describe('Fee Payment Integration Tests', async () => {
     AddressManager = system.AddressManager
     watcher = system.watcher
 
-    const ProxyGatewayAddress = await AddressManager.getAddress('Proxy__OVM_L1ETHGateway')
-    const GatewayAddress = await AddressManager.getAddress('OVM_L1ETHGateway')
-    const addressToUse = ProxyGatewayAddress != constants.AddressZero
-      ? ProxyGatewayAddress : GatewayAddress
-
-    OVM_L1ETHGateway = new Contract(
-      addressToUse,
-      l1GatewayInterface,
-      l1Wallet
+    const ProxyGatewayAddress = await AddressManager.getAddress(
+      'Proxy__OVM_L1ETHGateway'
     )
+    const GatewayAddress = await AddressManager.getAddress('OVM_L1ETHGateway')
+    const addressToUse =
+      ProxyGatewayAddress !== constants.AddressZero
+        ? ProxyGatewayAddress
+        : GatewayAddress
+
+    OVM_L1ETHGateway = new Contract(addressToUse, l1GatewayInterface, l1Wallet)
 
     OVM_ETH = new Contract(
       OVM_ETH_ADDRESS,

--- a/packages/x-domain/test/fee-payment.spec.ts
+++ b/packages/x-domain/test/fee-payment.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import assert = require('assert')
 import { JsonRpcProvider, TransactionResponse } from '@ethersproject/providers'
-import { BigNumber, Contract, Wallet, utils } from 'ethers'
+import { BigNumber, Contract, Wallet, utils, constants } from 'ethers'
 import { getContractInterface } from '@eth-optimism/contracts'
 import { Watcher } from '@eth-optimism/watcher'
 
@@ -61,8 +61,13 @@ describe('Fee Payment Integration Tests', async () => {
     AddressManager = system.AddressManager
     watcher = system.watcher
 
+    const ProxyGatewayAddress = await AddressManager.getAddress('Proxy__OVM_L1ETHGateway')
+    const GatewayAddress = await AddressManager.getAddress('OVM_L1ETHGateway')
+    const addressToUse = ProxyGatewayAddress != constants.AddressZero
+      ? ProxyGatewayAddress : GatewayAddress
+
     OVM_L1ETHGateway = new Contract(
-      await AddressManager.getAddress('OVM_L1ETHGateway'),
+      addressToUse,
       l1GatewayInterface,
       l1Wallet
     )

--- a/packages/x-domain/test/native-eth.spec.ts
+++ b/packages/x-domain/test/native-eth.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import assert = require('assert')
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { BigNumber, Contract, Wallet } from 'ethers'
+import { BigNumber, Contract, Wallet, constants } from 'ethers'
 import { getContractInterface } from '@eth-optimism/contracts'
 import { Watcher } from '@eth-optimism/watcher'
 
@@ -77,8 +77,13 @@ describe('Native ETH Integration Tests', async () => {
     l1bob = new Wallet(BOB_PRIV_KEY, l1Provider)
     l2bob = new Wallet(BOB_PRIV_KEY, l2Provider)
 
+    const ProxyGatewayAddress = await AddressManager.getAddress('Proxy__OVM_L1ETHGateway')
+    const GatewayAddress = await AddressManager.getAddress('OVM_L1ETHGateway')
+    const addressToUse = ProxyGatewayAddress != constants.AddressZero
+      ? ProxyGatewayAddress : GatewayAddress
+
     OVM_L1ETHGateway = new Contract(
-      await AddressManager.getAddress('OVM_L1ETHGateway'),
+      addressToUse,
       l1GatewayInterface,
       l1Wallet
     )

--- a/packages/x-domain/test/native-eth.spec.ts
+++ b/packages/x-domain/test/native-eth.spec.ts
@@ -77,16 +77,16 @@ describe('Native ETH Integration Tests', async () => {
     l1bob = new Wallet(BOB_PRIV_KEY, l1Provider)
     l2bob = new Wallet(BOB_PRIV_KEY, l2Provider)
 
-    const ProxyGatewayAddress = await AddressManager.getAddress('Proxy__OVM_L1ETHGateway')
-    const GatewayAddress = await AddressManager.getAddress('OVM_L1ETHGateway')
-    const addressToUse = ProxyGatewayAddress != constants.AddressZero
-      ? ProxyGatewayAddress : GatewayAddress
-
-    OVM_L1ETHGateway = new Contract(
-      addressToUse,
-      l1GatewayInterface,
-      l1Wallet
+    const ProxyGatewayAddress = await AddressManager.getAddress(
+      'Proxy__OVM_L1ETHGateway'
     )
+    const GatewayAddress = await AddressManager.getAddress('OVM_L1ETHGateway')
+    const addressToUse =
+      ProxyGatewayAddress !== constants.AddressZero
+        ? ProxyGatewayAddress
+        : GatewayAddress
+
+    OVM_L1ETHGateway = new Contract(addressToUse, l1GatewayInterface, l1Wallet)
 
     OVM_ETH = new Contract(
       OVM_ETH_ADDRESS,


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Conditionally uses the `Proxy__OVM_L1EthGateway` if nonzero.

blocks https://github.com/ethereum-optimism/contracts/pull/358